### PR TITLE
Fix web build

### DIFF
--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -29,7 +29,6 @@ naviz-animator = {path = "../animator"}
 naviz-parser = {path = "../parser"}
 naviz-renderer = {path = "../renderer"}
 naviz-state = {path = "../state"}
-naviz-video = {path = "../video"}
 rfd = "0.15.0"
 wgpu = {version = "*", features = ["webgl"]}# Enable webgl-support in wgpu
 
@@ -37,6 +36,7 @@ wgpu = {version = "*", features = ["webgl"]}# Enable webgl-support in wgpu
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.10"
 futures = {version = "0.3.30", default-features = false, features = ["executor", "thread-pool"]}
+naviz-video = {path = "../video"}
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/gui/src/animator_adapter.rs
+++ b/gui/src/animator_adapter.rs
@@ -107,6 +107,7 @@ impl AnimatorAdapter {
 
     /// Creates an [Animator] from this [AnimatorAdapter],
     /// or [None] if not enough inputs were set.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn animator(&self) -> Option<Animator> {
         if let (Some(machine), Some(visual), Some(instructions)) =
             (&self.machine, &self.visual, &self.instructions)

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -1,4 +1,5 @@
 use core::str;
+#[cfg(not(target_arch = "wasm32"))]
 use std::{sync::mpsc::channel, thread};
 
 use eframe::egui_wgpu::CallbackTrait;
@@ -6,6 +7,7 @@ use log::error;
 use naviz_parser::config::{machine::MachineConfig, visual::VisualConfig};
 use naviz_renderer::renderer::Renderer;
 use naviz_state::{config::Config, state::State};
+#[cfg(not(target_arch = "wasm32"))]
 use naviz_video::VideoExport;
 
 use crate::{
@@ -74,6 +76,7 @@ impl eframe::App for App {
                         .expect("Failed to convert to visual-config");
                     self.animator_adapter.set_visual_config(visual);
                 }
+                #[cfg(not(target_arch = "wasm32"))]
                 MenuEvent::ExportVideo {
                     target,
                     resolution,

--- a/gui/src/lib.rs
+++ b/gui/src/lib.rs
@@ -4,6 +4,7 @@ mod animator_adapter;
 mod app;
 mod aspect_panel;
 mod canvas;
+#[cfg(not(target_arch = "wasm32"))]
 mod export_dialog;
 mod future_helper;
 mod menu;


### PR DESCRIPTION
Previously used fields/functions only available on native platforms.
As video export is only implemented on native platforms, this is not a problem, but would fail the build.
Export-Menu is now own submodule, which is replaced by a stub on web.

Closes #28.