### PR TITLE
Simplify movement calculation in animator

### DIFF
--- a/animator/src/interpolator.rs
+++ b/animator/src/interpolator.rs
@@ -266,6 +266,13 @@ impl ConstantJerkImpl<MaxVelocity> for ConstantJerkFixedMaxVelocity {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct AverageVelocity(pub f32);
 
+impl AverageVelocity {
+    /// Gets the average velocity for a 2d move from `source` to `destination` in `time`
+    pub fn for_2d_move(source: Position, destination: Position, time: f32) -> Self {
+        Self(distance(source, destination) / time)
+    }
+}
+
 /// A [ConstantJerkImpl] with a set average velocity.
 /// The jerk value is calculated from the average velocity for a given interpolation.
 pub struct ConstantJerkFixedAverageVelocity();


### PR DESCRIPTION
Instead of calculating an `x`-jerk and a `y`-jerk for each move, simply save the average velocity and interpolate using `ConstantJerkFixedAverageVelocity`.
This reduces the amount of code used for the movements (though we will keep the unused parts at least for now).