### PR TITLE
Usability improvements

### DIFF
--- a/gui/src/menu.rs
+++ b/gui/src/menu.rs
@@ -288,6 +288,7 @@ impl MenuBar {
             ui.menu_button("File", |ui| {
                 if ui.button("Open").clicked() {
                     self.choose_file(FileType::Instructions, future_helper, MenuEvent::file_open);
+                    ui.close_menu();
                 }
 
                 ui.menu_button("Import", |ui| {
@@ -306,6 +307,7 @@ impl MenuBar {
                     ui.separator();
                     if ui.button("Quit").clicked() {
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                        ui.close_menu();
                     }
                 }
             });
@@ -373,6 +375,7 @@ impl MenuBar {
             ui.menu_button("Help", |ui| {
                 if ui.button("About").clicked() {
                     self.about_open = true;
+                    ui.close_menu();
                 }
             });
         });
@@ -543,6 +546,7 @@ pub mod export {
                 .clicked()
             {
                 self.export_settings.show();
+                ui.close_menu();
             }
         }
 


### PR DESCRIPTION
Allows dropping or pasting files into the application, where NAViz will deduce the type from the extension (both internal formats or imported formats) and load that file.
Also allows pasting instructions into the application.

Additionally, all menu buttons now close the menu when they are clicked.

Closes #49.