### PR TITLE
:bug: Dynamic content padding calculation for `Layout`

### DIFF
--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -213,11 +213,12 @@ impl Renderer {
 fn get_layout(config: &Config, screen_resolution: (u32, u32), force_content_only: bool) -> Layout {
     const LEGEND_HEIGHT: f32 = 1024.;
 
-    // Calculate dynamic content padding based on grid legend configuration
-    let content_padding_y = calculate_content_padding(&config.machine.grid.legend);
-
     // content source
     let content = ViewportSource::from_tl_br(config.content_extent.0, config.content_extent.1);
+
+    // Calculate dynamic content padding based on grid legend configuration and content dimensions
+    let content_padding_y =
+        calculate_content_padding(&config.machine.grid.legend, content.width, content.height);
 
     if force_content_only || (!config.display_time() && !config.display_sidebar()) {
         // no time and no sidebar
@@ -238,21 +239,51 @@ fn get_layout(config: &Config, screen_resolution: (u32, u32), force_content_only
 /// This replaces the hard-coded padding with dynamic calculation that considers:
 /// - Font size of coordinate labels
 /// - Whether labels and numbers are displayed
-/// - Minimum padding for visual breathing room
-fn calculate_content_padding(grid_legend: &naviz_state::config::GridLegendConfig) -> f32 {
-    const MIN_CONTENT_PADDING: f32 = 8.0; // Minimum padding for visual breathing room
-    const FONT_SIZE_MULTIPLIER: f32 = 1.5; // Extra space beyond font size
+/// - Additional space for text descenders and ascenders
+/// - Space for axis label identifiers (x, y labels)
+/// - Content aspect ratio to avoid excessive padding on tall/wide machines
+fn calculate_content_padding(
+    grid_legend: &naviz_state::config::GridLegendConfig,
+    content_width: f32,
+    content_height: f32,
+) -> f32 {
+    const MIN_CONTENT_PADDING: f32 = 12.0; // Minimum padding for visual breathing room
+    const FONT_SIZE_MULTIPLIER: f32 = 2.5; // Multiplier to account for ascenders/descenders and spacing
+    const AXIS_LABEL_EXTRA: f32 = 15.0; // Extra space for axis label identifiers (x, y)
+    const MAX_ASPECT_RATIO_SCALING: f32 = 4.0; // Cap the aspect ratio scaling effect
 
     // If neither labels nor numbers are displayed, use minimal padding
     if !grid_legend.display_labels && !grid_legend.display_numbers {
         return MIN_CONTENT_PADDING;
     }
 
-    // Calculate padding based on font size with some extra space
-    let font_based_padding = grid_legend.font.size * FONT_SIZE_MULTIPLIER;
+    // Calculate base padding from font size
+    let mut padding = grid_legend.font.size * FONT_SIZE_MULTIPLIER;
 
-    // Use the larger of minimum padding or font-based padding
-    font_based_padding.max(MIN_CONTENT_PADDING)
+    // Add extra space if labels are displayed (for axis identifiers like "x", "y")
+    if grid_legend.display_labels {
+        padding += AXIS_LABEL_EXTRA;
+    }
+
+    // Apply aggressive scaling for non-square machines
+    let aspect_ratio = content_height / content_width;
+
+    if aspect_ratio > 1.2 {
+        // For tall machines: use quadratic reduction that gets more aggressive as machines get taller
+        let clamped_ratio = aspect_ratio.min(MAX_ASPECT_RATIO_SCALING);
+        let mut reduction_factor = 1.2 / clamped_ratio;
+        reduction_factor = reduction_factor * reduction_factor;
+        padding *= reduction_factor;
+    } else if aspect_ratio < 0.83 {
+        // For wide machines: similar aggressive scaling
+        let clamped_ratio = aspect_ratio.max(1.0 / MAX_ASPECT_RATIO_SCALING);
+        let mut reduction_factor = clamped_ratio / 0.83;
+        reduction_factor = reduction_factor * reduction_factor;
+        padding *= reduction_factor;
+    }
+
+    // Use the larger of minimum padding or calculated padding
+    padding.max(MIN_CONTENT_PADDING)
 }
 
 #[cfg(test)]
@@ -310,8 +341,15 @@ mod test {
             display_numbers: true,
         };
 
-        let padding = calculate_content_padding(&grid_legend);
-        assert_eq!(padding, 18.0); // 12.0 * 1.5 = 18.0
+        // For content (800x600): aspect ratio = 0.75 < 0.83, so wide machine scaling applies
+        // reduction_factor = 0.75 / 0.83 = 0.903, squared = 0.816
+        // padding = 45.0 * 0.816 ≈ 36.74
+        let padding = calculate_content_padding(&grid_legend, 800.0, 600.0);
+        assert!(
+            (padding - 36.74).abs() < 0.01,
+            "Expected ~36.74, got {}",
+            padding
+        );
     }
 
     #[test]
@@ -331,8 +369,8 @@ mod test {
             display_numbers: false,
         };
 
-        let padding = calculate_content_padding(&grid_legend);
-        assert_eq!(padding, 8.0); // MIN_PADDING
+        let padding = calculate_content_padding(&grid_legend, 800.0, 600.0);
+        assert_eq!(padding, 12.0); // MIN_CONTENT_PADDING
     }
 
     #[test]
@@ -352,8 +390,16 @@ mod test {
             display_numbers: true,
         };
 
-        let padding = calculate_content_padding(&grid_legend);
-        assert_eq!(padding, 36.0); // 24.0 * 1.5 = 36.0
+        // For content (800x600): aspect ratio = 0.75 < 0.83, so wide machine scaling applies
+        // base padding = 24.0 * 2.5 + 15.0 = 75.0
+        // reduction_factor = 0.75 / 0.83 = 0.903, squared = 0.816
+        // padding = 75.0 * 0.816 ≈ 61.24
+        let padding = calculate_content_padding(&grid_legend, 800.0, 600.0);
+        assert!(
+            (padding - 61.24).abs() < 0.01,
+            "Expected ~61.24, got {}",
+            padding
+        );
     }
 
     #[test]
@@ -373,7 +419,85 @@ mod test {
             display_numbers: true,
         };
 
-        let padding = calculate_content_padding(&grid_legend);
-        assert_eq!(padding, 8.0); // max(4.0 * 1.5, 8.0) = 8.0 (MIN_PADDING)
+        // For content (800x600): aspect ratio = 0.75 < 0.83, so wide machine scaling applies
+        // base padding = 4.0 * 2.5 + 15.0 = 25.0
+        // reduction_factor = 0.75 / 0.83 = 0.903, squared = 0.816
+        // padding = 25.0 * 0.816 ≈ 20.41
+        let padding = calculate_content_padding(&grid_legend, 800.0, 600.0);
+        assert!(
+            (padding - 20.41).abs() < 0.01,
+            "Expected ~20.41, got {}",
+            padding
+        );
+    }
+
+    #[test]
+    fn calculate_content_padding_tall_machine() {
+        use naviz_state::config::{FontConfig, GridLegendConfig, HPosition, VPosition};
+
+        let grid_legend = GridLegendConfig {
+            step: (40., 40.),
+            font: FontConfig {
+                size: 12.,
+                color: [16, 16, 16, 255],
+                family: "Fira Mono".to_owned(),
+            },
+            labels: ("x".to_owned(), "y".to_owned()),
+            position: (VPosition::Bottom, HPosition::Left),
+            display_labels: true,
+            display_numbers: true,
+        };
+
+        // For very tall machine (100x2000): aspect ratio = 20.0 > 1.2, clamped to 4.0
+        // reduction_factor = 1.2 / 4.0 = 0.3, squared = 0.09
+        // padding = 45.0 * 0.09 = 4.05, but max with MIN_CONTENT_PADDING = 12.0
+        let padding = calculate_content_padding(&grid_legend, 100.0, 2000.0);
+        assert_eq!(padding, 12.0); // Should be the minimum padding
+    }
+
+    #[test]
+    fn calculate_content_padding_square_machine() {
+        use naviz_state::config::{FontConfig, GridLegendConfig, HPosition, VPosition};
+
+        let grid_legend = GridLegendConfig {
+            step: (40., 40.),
+            font: FontConfig {
+                size: 12.,
+                color: [16, 16, 16, 255],
+                family: "Fira Mono".to_owned(),
+            },
+            labels: ("x".to_owned(), "y".to_owned()),
+            position: (VPosition::Bottom, HPosition::Left),
+            display_labels: true,
+            display_numbers: true,
+        };
+
+        // For square machine (500x500): aspect ratio = 1.0, between 0.67 and 1.5, so no scaling
+        let padding = calculate_content_padding(&grid_legend, 500.0, 500.0);
+        assert_eq!(padding, 45.0);
+    }
+
+    #[test]
+    fn calculate_content_padding_moderately_tall_machine() {
+        use naviz_state::config::{FontConfig, GridLegendConfig, HPosition, VPosition};
+
+        let grid_legend = GridLegendConfig {
+            step: (40., 40.),
+            font: FontConfig {
+                size: 12.,
+                color: [16, 16, 16, 255],
+                family: "Fira Mono".to_owned(),
+            },
+            labels: ("x".to_owned(), "y".to_owned()),
+            position: (VPosition::Bottom, HPosition::Left),
+            display_labels: true,
+            display_numbers: true,
+        };
+
+        // For moderately tall machine (100x300): aspect ratio = 3.0 > 1.2
+        // reduction_factor = 1.2 / 3.0 = 0.4, squared = 0.16
+        // padding = 45.0 * 0.16 = 7.2, but max with MIN_CONTENT_PADDING = 12.0
+        let padding = calculate_content_padding(&grid_legend, 100.0, 300.0);
+        assert_eq!(padding, 12.0);
     }
 }

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -240,19 +240,19 @@ fn get_layout(config: &Config, screen_resolution: (u32, u32), force_content_only
 /// - Whether labels and numbers are displayed
 /// - Minimum padding for visual breathing room
 fn calculate_content_padding(grid_legend: &naviz_state::config::GridLegendConfig) -> f32 {
-    const MIN_PADDING: f32 = 8.0; // Minimum padding for visual breathing room
-    const PADDING_MULTIPLIER: f32 = 1.5; // Extra space beyond font size
+    const MIN_CONTENT_PADDING: f32 = 8.0; // Minimum padding for visual breathing room
+    const FONT_SIZE_MULTIPLIER: f32 = 1.5; // Extra space beyond font size
 
     // If neither labels nor numbers are displayed, use minimal padding
     if !grid_legend.display_labels && !grid_legend.display_numbers {
-        return MIN_PADDING;
+        return MIN_CONTENT_PADDING;
     }
 
     // Calculate padding based on font size with some extra space
-    let font_based_padding = grid_legend.font.size * PADDING_MULTIPLIER;
+    let font_based_padding = grid_legend.font.size * FONT_SIZE_MULTIPLIER;
 
     // Use the larger of minimum padding or font-based padding
-    font_based_padding.max(MIN_PADDING)
+    font_based_padding.max(MIN_CONTENT_PADDING)
 }
 
 #[cfg(test)]

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -211,25 +211,48 @@ impl Renderer {
 /// Will detect which [Layout] to use based on which parts should be displayed in the [Config].
 /// If `force_content_only` is `true`, will always use [Layout::new_content_only].
 fn get_layout(config: &Config, screen_resolution: (u32, u32), force_content_only: bool) -> Layout {
-    const CONTENT_PADDING_Y: f32 = 36.;
     const LEGEND_HEIGHT: f32 = 1024.;
+
+    // Calculate dynamic content padding based on grid legend configuration
+    let content_padding_y = calculate_content_padding(&config.machine.grid.legend);
 
     // content source
     let content = ViewportSource::from_tl_br(config.content_extent.0, config.content_extent.1);
 
     if force_content_only || (!config.display_time() && !config.display_sidebar()) {
         // no time and no sidebar
-        Layout::new_content_only(screen_resolution, content, CONTENT_PADDING_Y)
+        Layout::new_content_only(screen_resolution, content, content_padding_y)
     } else {
         // default layout
         Layout::new_full(
             screen_resolution,
             content,
-            CONTENT_PADDING_Y,
+            content_padding_y,
             LEGEND_HEIGHT,
             config.time.font.size * 1.2,
         )
     }
+}
+
+/// Calculates appropriate content padding based on the grid legend configuration.
+/// This replaces the hard-coded padding with dynamic calculation that considers:
+/// - Font size of coordinate labels
+/// - Whether labels and numbers are displayed
+/// - Minimum padding for visual breathing room
+fn calculate_content_padding(grid_legend: &naviz_state::config::GridLegendConfig) -> f32 {
+    const MIN_PADDING: f32 = 8.0; // Minimum padding for visual breathing room
+    const PADDING_MULTIPLIER: f32 = 1.5; // Extra space beyond font size
+
+    // If neither labels nor numbers are displayed, use minimal padding
+    if !grid_legend.display_labels && !grid_legend.display_numbers {
+        return MIN_PADDING;
+    }
+
+    // Calculate padding based on font size with some extra space
+    let font_based_padding = grid_legend.font.size * PADDING_MULTIPLIER;
+
+    // Use the larger of minimum padding or font-based padding
+    font_based_padding.max(MIN_PADDING)
 }
 
 #[cfg(test)]
@@ -268,5 +291,89 @@ mod test {
             layout.time.is_none(),
             "Example config without legend and time should not allocates space for time"
         );
+    }
+
+    #[test]
+    fn calculate_content_padding_with_labels_and_numbers() {
+        use naviz_state::config::{FontConfig, GridLegendConfig, HPosition, VPosition};
+
+        let grid_legend = GridLegendConfig {
+            step: (40., 40.),
+            font: FontConfig {
+                size: 12.,
+                color: [16, 16, 16, 255],
+                family: "Fira Mono".to_owned(),
+            },
+            labels: ("x".to_owned(), "y".to_owned()),
+            position: (VPosition::Bottom, HPosition::Left),
+            display_labels: true,
+            display_numbers: true,
+        };
+
+        let padding = calculate_content_padding(&grid_legend);
+        assert_eq!(padding, 18.0); // 12.0 * 1.5 = 18.0
+    }
+
+    #[test]
+    fn calculate_content_padding_no_display() {
+        use naviz_state::config::{FontConfig, GridLegendConfig, HPosition, VPosition};
+
+        let grid_legend = GridLegendConfig {
+            step: (40., 40.),
+            font: FontConfig {
+                size: 12.,
+                color: [16, 16, 16, 255],
+                family: "Fira Mono".to_owned(),
+            },
+            labels: ("x".to_owned(), "y".to_owned()),
+            position: (VPosition::Bottom, HPosition::Left),
+            display_labels: false,
+            display_numbers: false,
+        };
+
+        let padding = calculate_content_padding(&grid_legend);
+        assert_eq!(padding, 8.0); // MIN_PADDING
+    }
+
+    #[test]
+    fn calculate_content_padding_large_font() {
+        use naviz_state::config::{FontConfig, GridLegendConfig, HPosition, VPosition};
+
+        let grid_legend = GridLegendConfig {
+            step: (40., 40.),
+            font: FontConfig {
+                size: 24.,
+                color: [16, 16, 16, 255],
+                family: "Fira Mono".to_owned(),
+            },
+            labels: ("x".to_owned(), "y".to_owned()),
+            position: (VPosition::Bottom, HPosition::Left),
+            display_labels: true,
+            display_numbers: true,
+        };
+
+        let padding = calculate_content_padding(&grid_legend);
+        assert_eq!(padding, 36.0); // 24.0 * 1.5 = 36.0
+    }
+
+    #[test]
+    fn calculate_content_padding_small_font() {
+        use naviz_state::config::{FontConfig, GridLegendConfig, HPosition, VPosition};
+
+        let grid_legend = GridLegendConfig {
+            step: (40., 40.),
+            font: FontConfig {
+                size: 4.,
+                color: [16, 16, 16, 255],
+                family: "Fira Mono".to_owned(),
+            },
+            labels: ("x".to_owned(), "y".to_owned()),
+            position: (VPosition::Bottom, HPosition::Left),
+            display_labels: true,
+            display_numbers: true,
+        };
+
+        let padding = calculate_content_padding(&grid_legend);
+        assert_eq!(padding, 8.0); // max(4.0 * 1.5, 8.0) = 8.0 (MIN_PADDING)
     }
 }


### PR DESCRIPTION
## Description

This pull request improves how content padding is calculated in the renderer by replacing a hard-coded value with a dynamic calculation based on the grid legend configuration. It also adds comprehensive tests to ensure the new logic behaves correctly for different scenarios.

**Dynamic content padding calculation:**

* Added the `calculate_content_padding` function to compute padding based on the grid legend's font size, display settings, and a minimum threshold, replacing the previous fixed value. (`renderer/src/renderer.rs`)
* Updated the `get_layout` function to use the new dynamic padding calculation, ensuring layouts adapt visually to configuration changes. (`renderer/src/renderer.rs`)

**Testing enhancements:**

* Added five new unit tests for `calculate_content_padding`, covering cases with/without labels and numbers, and various font sizes to verify correct padding computation. (`renderer/src/renderer.rs`)

Fixes #86 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
