### PR TITLE
🍎 Restore support for x86 macOS systems

### DIFF
--- a/.github/workflows/desktop-build.yaml
+++ b/.github/workflows/desktop-build.yaml
@@ -23,7 +23,7 @@ jobs:
             env:
               CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           - image: macos-15-intel
-            arch: x86_64-apple-darwin
+            target: x86_64-apple-darwin
           - image: macos-14
             target: aarch64-apple-darwin
           - image: windows-2022

--- a/.github/workflows/desktop-build.yaml
+++ b/.github/workflows/desktop-build.yaml
@@ -22,6 +22,8 @@ jobs:
             prepare: sudo apt install -y gcc-aarch64-linux-gnu
             env:
               CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          - image: macos-15-intel
+            arch: x86_64-apple-darwin
           - image: macos-14
             target: aarch64-apple-darwin
           - image: windows-2022

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -29,6 +29,8 @@ jobs:
           - image: ubuntu-24.04-arm
             arch: aarch64
             manylinux: auto
+          - image: macos-15-intel
+            arch: x86_64-apple-darwin
           - image: macos-14
             arch: aarch64
           - image: windows-2022

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - image: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+          - image: macos-15-intel
+            arch: x86_64-apple-darwin
           - image: macos-14
             target: aarch64-apple-darwin
           - image: windows-2022

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           - image: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - image: macos-15-intel
-            arch: x86_64-apple-darwin
+            target: x86_64-apple-darwin
           - image: macos-14
             target: aarch64-apple-darwin
           - image: windows-2022
@@ -37,7 +37,6 @@ jobs:
       fail-fast: false
     name: Test ${{ matrix.target }}
     runs-on: ${{ matrix.image }}
-    env: ${{ matrix.env || fromJSON('{}')}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4^


### PR DESCRIPTION
## Description


This PR reverts #187, which dropped support for x86 macOS systems. This is because GitHub Actions has introduced a `macos-15-intel` runner, enabling us to test on x86 macOS until August 2027.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.