### PR TITLE
Set `video` to workspace-managed in `gui`

### DIFF
--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -42,7 +42,7 @@ wgpu = {version = "25", features = ["webgl"]} # Enable webgl-support in wgpu
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11"
 futures = {version = "0.3.30", default-features = false, features = ["executor", "thread-pool"]}
-naviz-video = {path = "../video"}
+naviz-video = {workspace = true}
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
## Description

The `video`-dependency in `gui` is still defined by path.
All dependencies were set to `workspace = true` to obtain a version (which is required for publishing) in ef2c60c, but the `video`-dependency in `gui` was missed (presumably because it is only pulled in for desktop-builds).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency resolution for improved build configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->