### PR TITLE
docs(python): fix wrong repository in readme

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,7 +21,7 @@ from naviz import *
 
 # Get machine and style from repository
 machine = Repository.machines().get("example")
-style = Repository.machines().get("tum")
+style = Repository.styles().get("tum")
 
 # Alternatively, you can also use manual configurations
 machine = "<...>"

--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ from naviz import *
 
 # Get machine and style from repository
 machine = Repository.machines().get("example")
-style = Repository.machines().get("tum")
+style = Repository.styles().get("tum")
 
 # Alternatively, you can also use manual configurations
 machine = "<...>"


### PR DESCRIPTION
## Description

The README for the python-bindings contained a copy-paste-error, which is fixed by this PR.
See #290 and #91.

On a side-note, maybe the python-README should go into the `bindings`-crate so it will be displayed on the [crate's page](https://crates.io/crates/naviz-bindings).

## Checklist:

- [X] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [X] I have updated the documentation to reflect these changes.
- [X] The changes follow the project's style guidelines and introduce no new warnings.
- [X] The changes are fully tested and pass the CI checks.
- [X] I have reviewed my own code changes.
