### PR TITLE
🔧 Maintenance round

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -29,9 +29,9 @@ jobs:
           - image: ubuntu-24.04-arm
             arch: aarch64
             manylinux: auto
-          - image: macos-15
+          - image: macos-26
             arch: aarch64
-          - image: macos-15-intel
+          - image: macos-26-intel
             arch: x86_64-apple-darwin
           - image: windows-2025
             arch: x86_64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,9 +26,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - image: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - image: macos-15
+          - image: macos-26
             target: aarch64-apple-darwin
-          - image: macos-15-intel
+          - image: macos-26-intel
             target: x86_64-apple-darwin
           - image: windows-2025
             target: x86_64-pc-windows-msvc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
     rev: v3.8.2
     hooks:
       - id: prettier
-        types_or: [yaml, markdown, html, css, scss, javascript, json]
+        types_or: [yaml, markdown, html, css, scss, javascript, json, json5]
         exclude: ^(gui/index.html|gui/assets/sw.js)
         priority: 1
 
@@ -122,21 +122,13 @@ repos:
     rev: v0.15.10
     hooks:
       - id: ruff-format
+        types_or: [python, pyi, jupyter, markdown]
         priority: 1
       - id: ruff-check
         require_serial: true
         priority: 2
 
   # Priority 2+: Final checks and fixers
-
-  ## Also run Black on examples in the documentation (needs to run after ruff format)
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.20.0
-    hooks:
-      - id: blacken-docs
-        language: python
-        additional_dependencies: [black==26.*]
-        priority: 2
 
   ## Static type checking using ty (needs to run after lockfile update/ruff format, and ruff lint)
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,6 @@ ci:
   skip: [cargo-fmt, ty-check]
 
 repos:
-  # Priority 0: Fast validation and independent fixers
-
   ## Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -26,14 +24,7 @@ repos:
       - id: end-of-file-fixer
         priority: 1
       - id: trailing-whitespace
-        priority: 1
-
-  ## Check the pyproject.toml file
-  - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.04.11
-    hooks:
-      - id: validate-pyproject
-        priority: 0
+        priority: 2
 
   ## Check JSON schemata
   - repo: https://github.com/python-jsonschema/check-jsonschema
@@ -44,23 +35,6 @@ repos:
       - id: check-readthedocs
         priority: 0
 
-  ## Catch common capitalization mistakes
-  - repo: local
-    hooks:
-      - id: disallow-caps
-        name: Disallow improper capitalization
-        language: pygrep
-        entry: '\b(?:Numpy|Github|PyTest|Tum)\b'
-        exclude: .pre-commit-config.yaml
-        priority: 0
-
-  ## Check for spelling
-  - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.45.0
-    hooks:
-      - id: typos
-        priority: 0
-
   ## Check best practices for scientific Python code
   - repo: https://github.com/scientific-python/cookie
     rev: 2026.04.04
@@ -69,14 +43,38 @@ repos:
         additional_dependencies: ["repo-review[cli]"]
         priority: 0
 
-  ## Ensure uv lock file is up-to-date
+  ## Check pyproject.toml file
+  - repo: https://github.com/henryiii/validate-pyproject-schema-store
+    rev: 2026.04.11
+    hooks:
+      - id: validate-pyproject
+        priority: 0
+
+  ## Ensure uv.lock is up to date
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.6
     hooks:
       - id: uv-lock
         priority: 0
 
-  ## Tidy up BibTeX files
+  ## Check for common capitalization mistakes
+  - repo: local
+    hooks:
+      - id: disallow-caps
+        name: Disallow improper capitalization
+        language: pygrep
+        entry: \b(Numpy|Github|PyTest|Tum)\b
+        exclude: ^(\.pre-commit-config\.yaml)$
+        priority: 0
+
+  ## Check for typos
+  - repo: https://github.com/adhtruong/mirrors-typos
+    rev: v1.45.0
+    hooks:
+      - id: typos
+        priority: 3
+
+  ## Format BibTeX files with bibtex-tidy
   - repo: https://github.com/FlamingTempura/bibtex-tidy
     rev: v1.14.0
     hooks:
@@ -93,20 +91,7 @@ repos:
             "--trailing-commas",
             "--remove-empty-fields",
           ]
-        priority: 0
-
-  # Priority 1: Second-pass fixers
-
-  ## Format Rust files
-  - repo: local
-    hooks:
-      - id: cargo-fmt
-        name: cargo fmt
-        entry: cargo fmt
-        language: unsupported
-        types: [rust]
-        pass_filenames: false
-        priority: 1
+        priority: 5
 
   ## Format configuration files with prettier
   - repo: https://github.com/rbubley/mirrors-prettier
@@ -115,22 +100,31 @@ repos:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json, json5]
         exclude: ^(gui/index.html|gui/assets/sw.js)
-        priority: 1
+        priority: 5
 
-  ## Python linting using ruff
+  ## Format Rust files with cargo fmt
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt
+        language: unsupported
+        types: [rust]
+        pass_filenames: false
+        priority: 5
+
+  ## Format and lint Python files with ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:
       - id: ruff-format
         types_or: [python, pyi, jupyter, markdown]
-        priority: 1
+        priority: 6
       - id: ruff-check
         require_serial: true
-        priority: 2
+        priority: 7
 
-  # Priority 2+: Final checks and fixers
-
-  ## Static type checking using ty (needs to run after lockfile update/ruff format, and ruff lint)
+  ## Check Python types with ty
   - repo: local
     hooks:
       - id: ty-check
@@ -141,4 +135,4 @@ repos:
         types_or: [python, pyi, jupyter]
         exclude: ^(docs/)
         pass_filenames: false
-        priority: 3
+        priority: 8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 from importlib import metadata
 
+try:
+    version = metadata.version("mqt.naviz")
+except ModuleNotFoundError:
+    msg = "mqt.naviz must be installed to build the documentation"
+    raise ModuleNotFoundError(msg) from None
+
 # Filter git details from version
-version = metadata.version("mqt.naviz")
 release = version.split("+")[0]
 
 project = "MQT NAViz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ show-fixes = true
 src = ["python"]
 
 [tool.ruff.format]
+preview = true
 docstring-code-format = true
 
 [tool.ruff.lint]
@@ -130,16 +131,15 @@ mch = "mch"
 ket = "ket"
 
 
-[tool.repo-review]
-ignore = [
-    "GH200", # We use Renovate instead of Dependabot
-    "MY100", # We use ty instead of mypy
-    "PC140", # We use ty instead of mypy
-    "PC160", # We use a mirror of crate-ci/typos
-    "PC170", # We do not use rST files anymore
-    "PP301", # We do not have tests yet
-    "PY005", # We do not have tests yet
-]
+[tool.repo-review.ignore]
+GH200 = "We use Renovate instead of Dependabot"
+MY100 = "We use ty instead of mypy"
+PC111 = "We use ruff instead of blacken-docs"
+PC140 = "We use ty instead of mypy"
+PC160 = "We use a mirror of crate-ci/typos"
+PC170 = "We do not use rST files anymore"
+PP301 = "We do not have tests yet"
+PY005 = "We do not have tests yet"
 
 
 [dependency-groups]


### PR DESCRIPTION
## Description

This PR combines several maintenance updates:

- Use `ruff format` instead of `blacken-docs`
- Use `macos-26` and `macos-26-intel` as default macOS runners
- Reconfigure `prek` priorities

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.