### PR TITLE
📝 Update templated files to v1.4.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,5 @@ This checklist serves as a reminder of a couple of things that ensure your pull 
 
 - [ ] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/naviz/blob/main/docs/ai_usage.md).
 - [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
-- [ ] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
+- [ ] I have disclosed AI assistance in the PR description.
 - [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,78 +5,100 @@ name-template: "MQT NAViz $RESOLVED_VERSION Release"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "🧑‍💻 Updates to the CLI"
-    labels:
-      - "Area: CLI"
+    when:
+      labels:
+        - "Area: CLI"
   - title: "📱 Updates to the GUI"
-    labels:
-      - "Area: GUI"
+    when:
+      labels:
+        - "Area: GUI"
   - title: "🐍 Updates to the Python Integration"
-    labels:
-      - "Area: Python"
+    when:
+      labels:
+        - "Area: Python"
   - title: "📼 Updates to the Video Export"
-    labels:
-      - "Area: Video Export"
+    when:
+      labels:
+        - "Area: Video Export"
   - title: "💫 Updates related to animation"
-    labels:
-      - "Area: Animation"
+    when:
+      labels:
+        - "Area: Animation"
   - title: "🔍️ Updates related to file parsing"
-    labels:
-      - "Area: File Parser"
+    when:
+      labels:
+        - "Area: File Parser"
   - title: "🔗 Updates related to supported import formats"
-    labels:
-      - "Area: Import"
+    when:
+      labels:
+        - "Area: Import"
   - title: "🖼️ Updates related to rendering"
-    labels:
-      - "Area: Renderer"
+    when:
+      labels:
+        - "Area: Renderer"
   - title: "🔧 Updates related to the machine repository"
-    labels:
-      - "Area: Repository"
+    when:
+      labels:
+        - "Area: Repository"
   - title: "🚀 Features and Enhancements"
-    labels:
-      - "enhancement"
-      - "feature"
-      - "refactor"
-      - "usability"
+    when:
+      labels:
+        - "enhancement"
+        - "feature"
+        - "refactor"
+        - "usability"
   - title: "🐛 Bug Fixes"
-    labels:
-      - "bug"
-      - "fix"
+    when:
+      labels:
+        - "bug"
+        - "fix"
   - title: "📄 Documentation"
-    labels:
-      - "documentation"
-  - title: "🤖 CI"
-    labels:
-      - "continuous integration"
+    when:
+      labels:
+        - "documentation"
+  - title: "🤖 CI & Tooling"
+    when:
+      labels:
+        - "continuous integration"
+        - "tooling"
   - title: "📦 Packaging"
-    labels:
-      - "packaging"
+    when:
+      labels:
+        - "packaging"
   - title: "🧹 Code Quality"
-    labels:
-      - "code quality"
+    when:
+      labels:
+        - "code quality"
   - title: "⬆️ Dependencies"
     collapse-after: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
-      - "pre-commit"
-      - "submodules"
+    when:
+      labels:
+        - "dependencies"
+        - "github-actions"
+        - "pre-commit"
+        - "submodules"
+  - type: "pre-exclude"
+    when:
+      labels:
+        - "skip-changelog"
+        - "backport"
+        - "release-prep"
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      label: "major"
+  - type: "version-resolver"
+    semver-increment: "minor"
+    when:
+      label: "minor"
+  - type: "version-resolver"
+    semver-increment: "patch"
+    when:
+      label: "patch"
+  - type: "version-resolver"
+    semver-increment: "patch"
 change-template: "- $TITLE ([#$NUMBER]($URL)) (**@$AUTHOR**)"
 change-title-escapes: '\<*_&'
-exclude-labels:
-  - "skip-changelog"
-  - "backport"
-  - "release-prep"
-version-resolver:
-  major:
-    labels:
-      - "major"
-  minor:
-    labels:
-      - "minor"
-  patch:
-    labels:
-      - "patch"
-  default: patch
 
 template: |
   $CHANGES

--- a/.github/workflow_inputs/release_drafter_categories.json
+++ b/.github/workflow_inputs/release_drafter_categories.json
@@ -16,7 +16,7 @@
   ],
   "🐛 Bug Fixes": ["bug", "fix"],
   "📄 Documentation": ["documentation"],
-  "🤖 CI": ["continuous integration"],
+  "🤖 CI & Tooling": ["continuous integration", "tooling"],
   "📦 Packaging": ["packaging"],
   "🧹 Code Quality": ["code quality"],
   "⬆️ Dependencies": [

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: munich-quantum-toolkit/templates@02460c7352d8d8a13414c9c082f062b33c3c5ecb # v1.4.1
+      - uses: munich-quantum-toolkit/templates@d0c5adb86d19a5095f871cb6184cfdab298e943c # v1.4.2
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: NAViz

--- a/docs/ai_usage.md
+++ b/docs/ai_usage.md
@@ -76,14 +76,16 @@ beginning of the edited field.
 Transparency helps the community understand the role of these tools and develop
 best practices.
 
-**You must disclose AI assistance.** This helps us understand how the tools are
-being used and identify potential issues. Disclose it in the following ways:
+**AI assistance must be disclosed in the PR description.** This helps reviewers
+understand how the tools were used and where human verification was applied.
 
-- **Commit Messages**: Add a trailer to your commit message in the form
-  `Assisted-by: [Model Name] via [Tool Name]` (example:
-  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`)
-- **Public issue and pull request text**: Use the visible disclosure required in
-  the [communication policy](#3-communication).
+- **PR Description**: Briefly state how AI tools materially assisted the
+  contribution. If an agent authored or edited the description, use the visible
+  disclosure required in the [communication policy](#3-communication).
+- **Commit Messages**: We recommend adding an
+  `Assisted-by: [Model Name] via [Tool Name]` trailer to commits prepared with
+  AI assistance. For example:
+  `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`.
 
 ### 5. Licensing and Copyright
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Roll out MQT Templates v1.4.2 at the exact signed release commit `d0c5adb86d19a5095f871cb6184cfdab298e943c`. This migrates the generated Release Drafter configuration, updates the repository policy files, and pins the templating workflow to that release. The repository-specific Release Drafter input remains in place and now names its category `CI & Tooling`, matching both `continuous integration` and `tooling`.

AI assistance was used to render, validate, and prepare this rollout.

## Validation

- Re-rendered all enabled templates from the exact v1.4.2 release with the repository workflow inputs
- Preserved and validated the custom Release Drafter category map
- `prek run --all-files`
- `git diff --check`

## Checklist

- [ ] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [ ] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/naviz/blob/main/docs/ai_usage.md).
- [ ] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [ ] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.