### PR TITLE
📌 Install `trunk` with `--locked` flag

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -41,7 +41,7 @@ jobs:
           cache-key: ${{ env.CACHE_KEY }}
           target: wasm32-unknown-unknown
       - name: Install trunk
-        run: cargo install trunk
+        run: cargo install --locked trunk
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0


### PR DESCRIPTION
## Description

This PR fixes the `trunk` installation in the CI by adding the `--locked` flag.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

