### PR TITLE
🐍 Switch to Stable ABI wheels

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.arch }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: "true"
           manylinux: ${{ matrix.manylinux }}
       - name: Upload wheels

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -21,6 +21,6 @@ naviz-import = {workspace = true, features = ["serde"]}
 naviz-parser = {workspace = true}
 naviz-repository = {workspace = true}
 naviz-video = {workspace = true}
-pyo3 = "0.29.0"
+pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 serde = "1.0.217"
 serde-pyobject = "0.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 ]


### PR DESCRIPTION
## Description

This PR configures `pyo3` to build Stable ABI wheels. This change should also make the wheels compatible with Python 3.15.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

