### PR TITLE
📌 Install `cargo-workspaces` with `--locked` flag

### DIFF
--- a/.github/workflows/rust-publish.yaml
+++ b/.github/workflows/rust-publish.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           cache-key: ${{ env.CACHE_KEY }}
       - name: Install Tools
-        run: cargo install cargo-workspaces
+        run: cargo install --locked cargo-workspaces
       - name: Authenticate using Trusted Publishing
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

The publish workflow failed because `cargo install cargo-workspaces` resolves the latest compatible transitive dependencies, which pulled in `kstring 2.0.4` requiring rustc 1.96.0 while the runner has 1.95.0. Adding `--locked` pins the dependencies to the versions the crate was published with, as already done for `trunk` in #567.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.