### PR TITLE
🐍 Replace deprecated `maturin upload` with `gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -69,7 +69,6 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
-          archive: false
 
   release:
     name: Release
@@ -80,20 +79,18 @@ jobs:
       name: pypi
       url: https://pypi.org/p/mqt-naviz
     permissions:
-      # Use to sign the release artifacts
       id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
       attestations: write
+      contents: read
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
       - name: Generate artifact attestation
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
-          subject-path: "wheels-*/*"
+          subject-path: dist/*
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

`maturin upload` and `maturin publish` are deprecated ([PyO3/maturin#2334](https://github.com/PyO3/maturin/issues/2334)) and emit a warning on every release run. This replaces the final step of the `Python Wheel` workflow with `pypa/gh-action-pypi-publish`, as used in the other MQT repositories.

Along the way, this also fixes the sdist never being attested or published: `archive: false` makes `upload-artifact` ignore the `name` input and use the file name instead, so the sdist artifact was called `mqt_naviz-0.3.0.tar.gz` and never matched the `wheels-*/*` glob. Accordingly, `v0.3.0` is on PyPI without an sdist, and its attestation only covers the five wheels. All artifacts are now collected in a single `dist` directory, which is used for both the attestation and the upload.

Fixes #583

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/naviz/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
