### PR TITLE
⬆️ Update templating action to v1.5.0

### DIFF
--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -40,5 +40,6 @@ jobs:
           repository: ${{ github.event.repository.name }}
           has-changelog-and-upgrade-guide: false
           synchronize-contribution-guide: false
+          synchronize-gitignore: false
           synchronize-installation-guide: false
           release-drafter-categories: ${{ steps.read-release-drafter-categories.outputs.release_drafter_categories }}

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -31,7 +31,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write # Needed to push the templating branch
           permission-pull-requests: write # Needed to open the templating pull request
-      - uses: munich-quantum-toolkit/templates@f87a5f152d33b64e3cc4fad41c402bf7ce892f5d # v1.4.3
+      - uses: munich-quantum-toolkit/templates@8caeb0bd8d0e2ebf906e7c3a826c06f72844a83b # v1.5.0
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: NAViz

--- a/.gitignore
+++ b/.gitignore
@@ -1,51 +1,79 @@
-# Rust build artifacts
-target/
-
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
 *.py[cod]
 *$py.class
-
-# Distribution / packaging
-.Python
-/build/
-/test/*/build
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
 *.so
 
-# Nox environments
-.nox/
+# Packaging
+/build/
+/dist/
+.eggs/
+*.egg
+*.egg-info/
+/_skbuild/
+/wheelhouse/
 
-# Sphinx documentation
+# Testing
+.coverage
+.coverage.*
+.hypothesis/
+.nox/
+.pytest_cache/
+.tox/
+*.cover
+*.profraw
+coverage.xml
+htmlcov/
+
+# Documentation
 docs/_build/
+docs/**/build/
 docs/api/
-docs/crates/
 
 # Environments
-.env*
-.venv*
+.env
+.env.*
+!.env.example
+!.env.*.example
+.venv/
+env/
+venv/
 
-# OS specific stuff
-.DS_Store
+# Tool caches
+.cache/
+.mypy_cache/
+.pyre/
+.pytype/
+.ruff_cache/
+.rumdl_cache/
 
-# IDEs and editors
+# Jupyter
+.ipynb_checkpoints/
+
+# Versioning
+python/**/_version.py
+src/**/_version.py
+
+# Editors
 .idea/
+.vs/
 .vscode/
-
-# Common editor files
-*~
 *.swp
+*~
+
+# Claude
+.claude/
+CLAUDE.md
+
+# Operating systems
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+
+# Custom
+/docs/crates/
+/target/


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Update the [munich-quantum-toolkit/templates](https://github.com/munich-quantum-toolkit/templates) action to v1.5.0. Align the local `.gitignore` with the shared base while retaining generated Rust API documentation and root Cargo build artifacts in a custom section. Remove the unused test-tree build rule so test output remains visible. Keep `.gitignore` synchronization explicitly disabled because the shared template does not cover these repository-specific rules.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.
